### PR TITLE
RSS Feedを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# rss feed
+/public/rss/atom.xml
+/public/rss/feed.json
+/public/rss/feed.xml

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -77,6 +77,10 @@ export const Layout = ({ title, description, slug, isHome = false, is404 = false
           /{' '}
           <a className="underline" href={`https://twitter.com/${defaultConfig.author}`} target="_blank" rel="noopener noreferrer">
             Twitter
+          </a>{' '}
+          /{' '}
+          <a className="underline" href={`/rss/feed.xml`} target="_blank" rel="noopener noreferrer">
+            RSS
           </a>
         </p>
 

--- a/lib/feed.ts
+++ b/lib/feed.ts
@@ -1,0 +1,49 @@
+import fs from 'fs'
+
+import { parseISO } from 'date-fns'
+import { Feed } from 'feed'
+
+import siteConfig from '../site.config.json'
+
+import { getPostDataForFeed } from './posts'
+
+export const generateRssFeed = async () => {
+  const baseUrl = process.env.NEXT_PUBLIC_HOST ?? ''
+  const { title, description, author } = siteConfig
+  const date = new Date()
+
+  const feed = new Feed({
+    title,
+    description,
+    id: baseUrl,
+    link: baseUrl,
+    language: 'ja',
+    favicon: `${baseUrl}/favicon.ico`,
+    copyright: `All rights reserved ${date.getFullYear()}, ${author}`,
+    updated: date,
+    feedLinks: {
+      rss2: `${baseUrl}/rss/feed.xml`,
+      json: `${baseUrl}/rss/feed.json`,
+      atom: `${baseUrl}/rss/atom.xml`,
+    },
+  })
+
+  const posts = await getPostDataForFeed()
+
+  posts.forEach((post) => {
+    const url = `${baseUrl}/posts/${post.id}`
+    feed.addItem({
+      title: post.title,
+      description: post.description ?? '',
+      id: url,
+      link: url,
+      content: post.contentHtml,
+      date: parseISO(post.date),
+    })
+  })
+
+  fs.mkdirSync('./public/rss', { recursive: true })
+  fs.writeFileSync('./public/rss/feed.xml', feed.rss2())
+  fs.writeFileSync('./public/rss/atom.xml', feed.atom1())
+  fs.writeFileSync('./public/rss/feed.json', feed.json1())
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -94,11 +94,5 @@ export const getPostDataForFeed = async () => {
 
   const allPosts: PostForFeed[] = await Promise.all(allPostsPromise)
 
-  return allPosts.sort((post1, post2) => {
-    if (post1.date < post2.date) {
-      return 1
-    } else {
-      return -1
-    }
-  })
+  return allPosts
 }

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -14,6 +14,14 @@ type Post = {
 }
 type MatterResultData = Omit<Post, 'id' | 'date'>
 
+type PostForFeed = {
+  id: string
+  contentHtml: string
+  date: string
+  title: string
+  description?: string
+}
+
 const postsDirectory = path.join(process.cwd(), 'posts')
 
 export const getSortedPostData = (): Post[] => {
@@ -68,4 +76,29 @@ export const getPostData = async (id: string) => {
     contentHtml,
     ...(matterResult.data as MatterResultData),
   }
+}
+
+export const getPostDataForFeed = async () => {
+  const allPostsPromise = getSortedPostData().map(async (post) => {
+    const { id, title, description, date } = post
+    const { contentHtml } = await getPostData(id)
+
+    return {
+      id,
+      contentHtml,
+      description,
+      date,
+      title,
+    }
+  })
+
+  const allPosts: PostForFeed[] = await Promise.all(allPostsPromise)
+
+  return allPosts.sort((post1, post2) => {
+    if (post1.date < post2.date) {
+      return 1
+    } else {
+      return -1
+    }
+  })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-config-next": "^13.1.1",
         "eslint-config-smarthr": "^6.5.0",
         "eslint-plugin-tailwindcss": "^3.8.0",
+        "feed": "^4.2.2",
         "postcss": "^8.4.21",
         "prettier": "^2.8.2",
         "typescript": "^4.9.4"
@@ -2270,6 +2271,18 @@
       "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dev": true,
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4807,6 +4820,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "dev": true
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -5569,6 +5588,18 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -7179,6 +7210,15 @@
       "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dev": true,
+      "requires": {
+        "xml-js": "^1.6.11"
       }
     },
     "file-entry-cache": {
@@ -8813,6 +8853,12 @@
         "is-regex": "^1.1.4"
       }
     },
+    "sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "dev": true
+    },
     "scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -9359,6 +9405,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
+      "requires": {
+        "sax": "^1.2.4"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-config-next": "^13.1.1",
     "eslint-config-smarthr": "^6.5.0",
     "eslint-plugin-tailwindcss": "^3.8.0",
+    "feed": "^4.2.2",
     "postcss": "^8.4.21",
     "prettier": "^2.8.2",
     "typescript": "^4.9.4"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,9 +4,11 @@ import React from 'react'
 
 import { Datetime } from '../components/Datetime'
 import { Layout } from '../components/Layout'
+import { generateRssFeed } from '../lib/feed'
 import { getSortedPostData } from '../lib/posts'
 
 export const getStaticProps: GetStaticProps = async () => {
+  await generateRssFeed()
   const allPosts = getSortedPostData()
 
   return {


### PR DESCRIPTION
## 概要

- いつもnabeliwoさんのnippo(週報)を読ませていただいています
- せっかくなので更新をフィードで確認できたらいいなと思い、RSS Feedの生成部分を実装して追加してみました

## 詳細

- `feed`というライブラリを使っています
  - [tagucch/random\.tagucch\.dev: https://random\.tagucch\.dev/](https://github.com/tagucch/random.tagucch.dev)で使っているという実績だけで選んでしまいました
  - 一応npm trendsは[feed vs rss \| npm trends](https://npmtrends.com/feed-vs-rss)こんな感じなので、`feed`を使うのが丸いのかなと思っています
- feedの生成部分も[tagucch/random\.tagucch\.dev: https://random\.tagucch\.dev/](https://github.com/tagucch/random.tagucch.dev)で行っている処理をほぼそのまま採用してみました(普段自分のpostを更新して得られるFeedの情報に特に不満はないため問題ないかなと思って実装しました)
- RSSのリンクは以下のような感じで配置してみました

![スクリーンショット 2023-10-04 2 14 07](https://github.com/nabeliwo/nippo/assets/19406706/85aaabeb-100c-4091-8f7c-1265d5176810)

- 実際に表示されるXMLはこんな感じです

![スクリーンショット 2023-10-04 2 26 01](https://github.com/nabeliwo/nippo/assets/19406706/bfae6dce-539a-4f6c-b399-3878dc64b445)
